### PR TITLE
Fix Issue 1

### DIFF
--- a/mail/views.py
+++ b/mail/views.py
@@ -62,7 +62,7 @@ def compose(request):
             sender=request.user,
             subject=subject,
             body=body,
-            read=user == request.user
+            read=False
         )
         email.save()
         for recipient in recipients:


### PR DESCRIPTION
Hi, 

I found a way to make the preview color also shown in the sent section for senders by making a small adjustment. After the adjustment, when the sender first sends out a mail, the default color will be white. After the email was read, the color in the sent section will be adjusted to grey. Hope this helps.
fix #1 

Victoria